### PR TITLE
Fix missing sudo in pre-commit installation

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -93,7 +93,7 @@ check_github_cli() {
             brew install gh
             gh auth login
         elif [[ "$OSTYPE" == "linux"* ]]; then
-            type -p curl >/dev/null || apt install curl -y
+            type -p curl >/dev/null || sudo apt install curl -y
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
             && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
             && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \


### PR DESCRIPTION
セットアップスクリプトでpre-commitのインストール時にsudoが不足していた問題を修正しました。