### PR TITLE
fix: setup.shのnpmグローバルインストールにsudoを追加

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -131,7 +131,7 @@ check_play_command() {
 check_claude_code() {
     if ! command -v claude &> /dev/null; then
         print_step "Installing Claude Code..."
-        npm i -g @anthropic-ai/claude-code
+        sudo npm i -g @anthropic-ai/claude-code
         print_success "Claude Code installed"
         print_step "Checking Claude Code..."
         claude --version
@@ -142,7 +142,7 @@ check_claude_code() {
 check_gemini_cli() {
     if ! command -v gemini &> /dev/null; then
         print_step "Installing Gemini CLI..."
-        npm install -g @google/gemini-cli
+        sudo npm install -g @google/gemini-cli
         print_success "Gemini CLI installed"
         print_step "Checking Gemini CLI..."
         gemini --version


### PR DESCRIPTION
## Summary
- Claude CodeとGemini CLIのnpmグローバルインストールコマンドに`sudo`を追加
- 権限不足によるインストール失敗を防ぐための修正

## 変更内容
- `npm i -g @anthropic-ai/claude-code` → `sudo npm i -g @anthropic-ai/claude-code`
- `npm install -g @google/gemini-cli` → `sudo npm install -g @google/gemini-cli`

## Test plan
- [x] setup.shスクリプトの構文エラーがないことを確認
- [ ] 実際にsetup.shを実行してClaude CodeとGemini CLIがインストールされることを確認
- [ ] 権限エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)