### PR TITLE
refactor: templateディレクトリの管理とpyright設定の最適化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,3 @@ coverage.xml
 
 # Project specific
 .secrets.baseline
-
-# template package
-template/
-!template/src/template_package/*
-!template/tests/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ typeCheckingMode = "standard"
 
 # Type checking behavior
 strictParameterNoneValue = false
-enablePytestSupport = true
 
 # 重要なエラー（必ずエラーとして報告）
 reportMissingImports = "error"

--- a/template/src/template_package/core/__init__.py
+++ b/template/src/template_package/core/__init__.py
@@ -1,0 +1,9 @@
+"""Core functionality of the package."""
+
+from .example import ExampleClass, ExampleConfig, process_data
+
+__all__ = [
+    "ExampleClass",
+    "ExampleConfig",
+    "process_data",
+]

--- a/template/src/template_package/utils/__init__.py
+++ b/template/src/template_package/utils/__init__.py
@@ -1,0 +1,14 @@
+"""Utility functions for the package."""
+
+from .helpers import chunk_list, flatten_dict, load_json_file, save_json_file
+from .logging_config import get_logger, set_log_level, setup_logging
+
+__all__ = [
+    "chunk_list",
+    "flatten_dict",
+    "get_logger",
+    "load_json_file",
+    "save_json_file",
+    "set_log_level",
+    "setup_logging",
+]


### PR DESCRIPTION
## Summary
- .gitignoreからtemplateディレクトリの除外設定を削除し、完全にバージョン管理対象に変更
- pyproject.tomlからenablePytestSupport設定を削除（デフォルト値で十分）
- 不足していたtemplate/core/__init__.pyとtemplate/utils/__init__.pyを追加

## Test plan
- [x] make check-allが成功することを確認
- [x] pre-commitフックが正常に動作することを確認
- [x] pyrightの型チェックが正常に動作することを確認

## 背景
pyrightの設定を程よいレベルに調整する一環で、templateディレクトリの管理方法を整理し、不要な設定を削除しました。

🤖 Generated with [Claude Code](https://claude.ai/code)